### PR TITLE
Feat: 챗봇 스크랩 페이지 UI 구현

### DIFF
--- a/src/components/ChatbotBox/ChatbotBox.jsx
+++ b/src/components/ChatbotBox/ChatbotBox.jsx
@@ -1,0 +1,66 @@
+import Badge from "../Badge/Badge";
+import * as S from "./ChatbotBoxStyle";
+import * as F from "../Filter/FilterStyle";
+import * as C from "../Chatbot/ChatbotStyle";
+import { useState } from "react";
+
+// category : 해당 채팅이 있었던 공문의 카테고리
+// title : AI 응답 요약
+// userChat : 사용자 메세지
+// aiChat : ai 메세지
+// expanded : 컴포넌트 펼침 상태
+// onToggle : 펼치고 접음 컨트롤
+export default function ChatbotBox({
+  category,
+  title,
+  userChat,
+  aiChat,
+  expanded = false,
+  onToggle,
+}) {
+  return (
+    <S.ChatbotWrapper>
+      <S.ContentContainer>
+        <S.ContentBox>
+          <S.BadgeBox>
+            <Badge color='teal'>{category}</Badge>
+          </S.BadgeBox>
+          <S.Title>{title}</S.Title>
+        </S.ContentBox>
+        <F.chevronBtn
+          type='button'
+          $expanded={expanded}
+          onClick={onToggle}
+        ></F.chevronBtn>
+      </S.ContentContainer>
+      {/* 챗봇 상세 내용 (펼쳤을 때) : Chatbot에서 가져옴 */}
+      {expanded && (
+        <>
+          <S.DetailWrapper>
+            <C.Chats>
+              <C.UserChatWrapper>
+                <C.UserChat
+                  style={{ backgroundColor: "var(--color-base-white)" }}
+                >
+                  {userChat}
+                </C.UserChat>
+              </C.UserChatWrapper>
+              <C.AIChatWrapper>
+                <C.AIProfile />
+                <C.AIChat>
+                  <C.AIChatContent>{aiChat}</C.AIChatContent>
+                </C.AIChat>
+              </C.AIChatWrapper>
+            </C.Chats>
+          </S.DetailWrapper>
+          {/* 펼쳤을 때만 보이는 삭제, 접기 버튼 */}
+          <S.ButtonWrapper>
+            <S.Button>스크랩 삭제</S.Button>
+            <S.Divide></S.Divide>
+            <S.Button onClick={onToggle}>접기</S.Button>
+          </S.ButtonWrapper>
+        </>
+      )}
+    </S.ChatbotWrapper>
+  );
+}

--- a/src/components/ChatbotBox/ChatbotBoxStyle.js
+++ b/src/components/ChatbotBox/ChatbotBoxStyle.js
@@ -1,0 +1,78 @@
+import styled from "styled-components";
+
+export const ChatbotWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 24px;
+  background: var(--color-neutral-100);
+`;
+
+export const ContentContainer = styled.div`
+  display: flex;
+  width: 100%;
+  padding: 12px 8px;
+  justify-content: space-between;
+  align-items: center;
+  flex-shrink: 0;
+  border-bottom: 0.5px solid var(--color-neutral-tertiary);
+  background: var(--color-base-white);
+`;
+
+export const ContentBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+`;
+
+export const BadgeBox = styled.div`
+  display: flex;
+  align-items: flex-start;
+`;
+
+export const Title = styled.div`
+  color: var(--color-base-black);
+  font-size: var(--Body-md-font-size);
+  font-weight: 500;
+  line-height: var(--Body-md-line-height);
+`;
+
+export const DetailWrapper = styled.div`
+  display: flex;
+  padding: 0 12px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 20px;
+  align-self: stretch;
+`;
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-top: 0.5px solid var(--color-neutral-tertiary);
+  border-bottom: 0.5px solid var(--color-neutral-tertiary);
+  background: var(--color-base-white);
+  width: 100%;
+  position: relative;
+`;
+
+export const Button = styled.button`
+  display: flex;
+  padding: 12px 0;
+  justify-content: center;
+  align-items: center;
+  flex: 1 0 0;
+`;
+
+export const Divide = styled.div`
+  height: 100%;
+  background-color: var(--color-neutral-tertiary);
+  position: absolute;
+  width: 0.5px;
+  left: 50%;
+
+  transform: translateX(-50%);
+  pointer-events: none;
+`;

--- a/src/components/GoToTop/GoToTop.jsx
+++ b/src/components/GoToTop/GoToTop.jsx
@@ -8,7 +8,7 @@ export default function GoToTop() {
   useEffect(() => {
     const handleScroll = () => {
       // 200px 이상 스크롤되면 isVisible 상태를 true로 변경
-      if (window.scrollY > 200) {
+      if (window.scrollY > 100) {
         setIsVisible(true);
       } else {
         setIsVisible(false);

--- a/src/pages/MyPage/MyPage.jsx
+++ b/src/pages/MyPage/MyPage.jsx
@@ -7,6 +7,7 @@ import useFetch from "../../hooks/useFetch";
 import { useEffect } from "react";
 import CardList from "../../components/CardList/CardList";
 import useProfile from "../../services/useProfile";
+import ChatbotBox from "../../components/ChatbotBox/ChatbotBox";
 
 const API_URL = process.env.REACT_APP_API_URL;
 
@@ -22,8 +23,44 @@ export default function MyPage() {
     []
   );
 
-  //  챗봇 스크랩
-  let scrapedChatbots = [];
+  // 챗봇 스크랩 (더미데이터)
+  const scrapedChatbots = [
+    {
+      id: 1,
+      category: "시설",
+      title: "AI 응답 요약",
+      userChat: "사용자 텍스트가 들어가는 자리",
+      aiChat: "AI 답변이 들어가는 자리",
+    },
+    {
+      id: 2,
+      category: "시설",
+      title: "AI 응답 요약",
+      userChat: "사용자 텍스트가 들어가는 자리",
+      aiChat: "AI 답변이 들어가는 자리",
+    },
+    {
+      id: 3,
+      category: "시설",
+      title: "AI 응답 요약",
+      userChat: "사용자 텍스트가 들어가는 자리",
+      aiChat: "AI 답변이 들어가는 자리",
+    },
+    {
+      id: 4,
+      category: "시설",
+      title: "AI 응답 요약",
+      userChat: "사용자 텍스트가 들어가는 자리",
+      aiChat: "AI 답변이 들어가는 자리",
+    },
+    {
+      id: 5,
+      category: "시설",
+      title: "AI 응답 요약",
+      userChat: "사용자 텍스트가 들어가는 자리",
+      aiChat: "AI 답변이 들어가는 자리",
+    },
+  ];
 
   return (
     <>
@@ -115,7 +152,9 @@ export default function MyPage() {
             </H.SectionHeader>
             {scrapedChatbots.length !== 0 ? (
               <H.CardListWrapper>
-                {/* 챗봇 컴포넌트 따로 만들어야 함 */}
+                {scrapedChatbots?.slice(0, 3).map((c) => (
+                  <ChatbotBox id={c.id} category={c.category} title={c.title} />
+                ))}
               </H.CardListWrapper>
             ) : (
               <>

--- a/src/pages/ScrapedChatbots/ScrapedChatbotStyle.js
+++ b/src/pages/ScrapedChatbots/ScrapedChatbotStyle.js
@@ -1,0 +1,7 @@
+import styled from "styled-components";
+
+export const ContentContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 0 16px;
+`;

--- a/src/pages/ScrapedChatbots/ScrapedChatbots.jsx
+++ b/src/pages/ScrapedChatbots/ScrapedChatbots.jsx
@@ -1,5 +1,136 @@
+import { useRef, useState } from "react";
+
 import * as S from "./ScrapedChatbotStyle";
+import * as P from "../ScrapedPosts/ScrapedPostsStyle";
+import * as F from "../../components/SmallFilter/SmallFilterStyle";
+import * as D from "../Search/SearchStyle";
+
+import GoToTop from "../../components/GoToTop/GoToTop";
+import Header from "../../components/Header/Header";
+import { ButtonWrapper } from "../../styles/ButtonCircle";
+import { useChatbotSmallFilter } from "../../services/smallFilter";
+import { CATEGORY_OPTIONS } from "../../services/filter";
+import Button from "../../components/Button/Button";
+import ChatbotBox from "../../components/ChatbotBox/ChatbotBox";
+
+import DropIcon from "../../assets/Back Icon.svg";
 
 export default function ScrapedChatbots() {
-  return <div>스크랩한 챗봇 페이지</div>;
+  // 필터 관련
+  const labels = CATEGORY_OPTIONS; // 모든 카테고리 배열
+  const { selected, toggle } = useChatbotSmallFilter(labels, labels[0]);
+
+  // 최신순, 오래된순 정렬 => 기본값은 최신순
+  const [sortOrder, setSortOrder] = useState("최신순");
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const dropdownRef = useRef(null);
+
+  // 챗봇 스크랩 (더미데이터)
+  const scrapedChatbots = [
+    {
+      id: 1,
+      category: "시설",
+      title: "AI 응답 요약",
+      userChat: "사용자 텍스트가 들어가는 자리",
+      aiChat: "AI 답변이 들어가는 자리",
+    },
+    {
+      id: 2,
+      category: "시설",
+      title: "AI 응답 요약",
+      userChat: "사용자 텍스트가 들어가는 자리",
+      aiChat: "AI 답변이 들어가는 자리",
+    },
+    {
+      id: 3,
+      category: "시설",
+      title: "AI 응답 요약",
+      userChat: "사용자 텍스트가 들어가는 자리",
+      aiChat: "AI 답변이 들어가는 자리",
+    },
+    {
+      id: 4,
+      category: "시설",
+      title: "AI 응답 요약",
+      userChat: "사용자 텍스트가 들어가는 자리",
+      aiChat: "AI 답변이 들어가는 자리",
+    },
+    {
+      id: 5,
+      category: "시설",
+      title: "AI 응답 요약",
+      userChat: "사용자 텍스트가 들어가는 자리",
+      aiChat: "AI 답변이 들어가는 자리",
+    },
+  ];
+
+  // 한 번에 하나만 열리도록
+  const [openId, setOpenId] = useState(null);
+  const handleToggle = (id) => {
+    setOpenId((prev) => (prev === id ? null : id)); // 이미 열려있으면 닫기, 아니면 새로 열기
+  };
+
+  return (
+    <>
+      {/* fixed 되는 컴포넌트들 */}
+      <Header hasBack={true} title='챗봇 스크랩' hasScrap={false} />
+      <ButtonWrapper>
+        <GoToTop />
+      </ButtonWrapper>
+      <P.ScrapedContainer>
+        {/* 챗봇 스크랩 전용 Small Filter */}
+        <F.SmallFilterWrapper>
+          {labels.map((label) => (
+            <Button
+              key={label}
+              label={label}
+              checked={selected.has(label)}
+              onChange={() => toggle(label)}
+            />
+          ))}
+        </F.SmallFilterWrapper>
+        <P.OrderContainer>
+          {/* Search에서 가져온 Dropdown */}
+          <D.ResultHeader>
+            <D.ResultCount>{scrapedChatbots?.length}건</D.ResultCount>
+            <D.SortWrapper ref={dropdownRef}>
+              <D.SortButton onClick={() => setIsDropdownOpen(!isDropdownOpen)}>
+                {sortOrder}
+                <img src={DropIcon} />
+              </D.SortButton>
+              {isDropdownOpen && (
+                <D.DropdownMenu>
+                  <D.DropdownItem
+                    onClick={() => handleSortChange("최신순")}
+                    $isSelected={sortOrder === "최신순"}
+                  >
+                    최신순
+                  </D.DropdownItem>
+                  <D.DropdownItem
+                    onClick={() => handleSortChange("오래된순")}
+                    $isSelected={sortOrder === "오래된순"}
+                  >
+                    오래된순
+                  </D.DropdownItem>
+                </D.DropdownMenu>
+              )}
+            </D.SortWrapper>
+          </D.ResultHeader>
+        </P.OrderContainer>
+        <S.ContentContainer>
+          {scrapedChatbots.map((c) => (
+            <ChatbotBox
+              id={c.id}
+              category={c.category}
+              title={c.title}
+              userChat={c.userChat}
+              aiChat={c.aiChat}
+              expanded={openId === c.id}
+              onToggle={() => handleToggle(c.id)}
+            />
+          ))}
+        </S.ContentContainer>
+      </P.ScrapedContainer>
+    </>
+  );
 }

--- a/src/pages/ScrapedPosts/ScrapedPosts.jsx
+++ b/src/pages/ScrapedPosts/ScrapedPosts.jsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from "react";
 import useFetch from "../../hooks/useFetch";
 
 import * as S from "./ScrapedPostsStyle";
-import * as H from "../Home/HomeStyle";
 import * as D from "../Search/SearchStyle";
 
 import GoToTop from "../../components/GoToTop/GoToTop";
@@ -80,7 +79,7 @@ export default function ScrapedPosts() {
           </D.ResultHeader>
         </S.OrderContainer>
 
-        <H.CardListWrapper>
+        <S.PostsWrapper>
           {!isPostsLoading && scrapedPosts && (
             <>
               {scrapedPosts?.map((p) => (
@@ -96,7 +95,7 @@ export default function ScrapedPosts() {
               ))}
             </>
           )}
-        </H.CardListWrapper>
+        </S.PostsWrapper>
       </S.ScrapedContainer>
     </>
   );

--- a/src/pages/ScrapedPosts/ScrapedPostsStyle.js
+++ b/src/pages/ScrapedPosts/ScrapedPostsStyle.js
@@ -12,22 +12,8 @@ export const OrderContainer = styled.div`
   padding: 0 24px;
 `;
 
-export const ResultBox = styled.div`
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 1;
-  color: var(--color-neutral-600);
-  font-size: var(--Body-sm-font-size);
-  font-weight: 500;
-  line-height: var(--Body-sm-line-height);
-  letter-spacing: -0.1px;
-`;
-
-export const OrderBtn = styled.button`
+export const PostsWrapper = styled.div`
   display: flex;
-  padding: 8px 0;
-  align-items: center;
-  gap: 5px;
-  flex-wrap: nowrap;
-  cursor: pointer;
+  flex-direction: column;
+  padding: 0 16px;
 `;

--- a/src/services/filter.js
+++ b/src/services/filter.js
@@ -5,11 +5,11 @@ import useProfile from "./useProfile";
 export const CATEGORY_OPTIONS = [
   "모든 주제",
   "교통",
-  "안전",
+  "문화",
   "주택",
   "경제",
   "환경",
-  "문화",
+  "안전",
   "복지",
   "행정",
 ];

--- a/src/services/smallFilter.js
+++ b/src/services/smallFilter.js
@@ -1,5 +1,6 @@
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import useProfile from "./useProfile";
+import { CATEGORY_OPTIONS } from "./filter";
 
 // 유저 프로필에서 필터 라벨 가져옴
 export function useProfileLabels(key) {
@@ -24,15 +25,25 @@ export function useProfileLabels(key) {
 }
 
 // 유저 프로필에서 가져온 라벨로만 이루어진 필터
-export function useSmallFilter(labels) {
+export function useSmallFilter(labels = []) {
   const [selected, setSelected] = useState(() => new Set());
 
-  const toggle = (label) =>
+  useEffect(() => {
+    const L = new Set(labels);
+    setSelected((prev) => {
+      const next = new Set([...prev].filter((l) => L.has(l)));
+      return next.size === prev.size ? prev : next;
+    });
+  }, [labels]);
+
+  const toggle = (label) => {
+    if (!labels.includes(label)) return;
     setSelected((prev) => {
       const next = new Set(prev);
       next.has(label) ? next.delete(label) : next.add(label);
       return next;
     });
+  };
 
   // 연동 할 때 쓰일 예정 : 실제 공문 필터링 하는 로직
   // const makePredicate = (key) => {
@@ -48,4 +59,68 @@ export function useSmallFilter(labels) {
   // }
 
   return { selected, toggle }; // 여기에 makePredicate도 추가될 예정
+}
+
+// 챗봇 스크랩용 SmallFilter : 모든 카테고리를 보여줌
+export function useChatbotSmallFilter(labels, allOption) {
+  const L = useMemo(() => new Set(labels), [labels]); // 넘겨 받은 배열에서 중복 제거
+  const hasAll = L.has(allOption); // allOption이 배열 안에 있는 옵션인지 확인
+
+  // 초기값: allOption이 존재하면 '모든 주제' 선택, 없으면 빈 선택
+  const [selected, setSelected] = useState(
+    () => hasAll && new Set([allOption])
+  );
+
+  // labels가 바뀔 때 : 유효하지 않은 선택 제거 + 비었으면 allOption 복구
+  useEffect(() => {
+    setSelected((prev) => {
+      const next = new Set([...prev].filter((v) => L.has(v)));
+      if (hasAll && next.size === 0) next.add(allOption);
+
+      const sameSize = next.size === prev.size;
+      const same = sameSize && [...next].every((v) => prev.has(v));
+      return same ? prev : next;
+    });
+  }, [L, hasAll, allOption]);
+
+  // 토글: allOption 클릭 시 allOption만 유지,
+  // 개별 옵션 클릭 시 allOption 해제, 모두 해제되면 allOption 복귀
+  const toggle = useCallback(
+    (label) => {
+      if (!L.has(label)) return;
+
+      setSelected((prev) => {
+        // all 클릭
+        if (hasAll && label === allOption) {
+          return new Set([allOption]);
+        }
+
+        // 개별 토글
+        const next = new Set(prev);
+        next.has(label) ? next.delete(label) : next.add(label);
+
+        // 개별이 하나라도 있으면 all 해제
+        if (hasAll && next.has(allOption)) next.delete(allOption);
+
+        // 모두 해제되면 all 복귀
+        if (hasAll && next.size === 0) next.add(allOption);
+
+        return next;
+      });
+    },
+    [L, hasAll, allOption]
+  );
+
+  // 연동시 실제 필터에 사용
+  // const makePredicate = useCallback(
+  //   (key) => {
+  //     if (hasAll && selected.has(allOption)) return () => true;
+  //     const S = new Set(selected);
+  //     if (key === "user_regions") return (item) => S.has(item?.region?.district);
+  //     return (item) => S.has(item?.category?.category_name);
+  //   },
+  //   [selected, hasAll, allOption]
+  // );
+
+  return { selected, toggle }; // 추후 makePredicate 추가 예정
 }


### PR DESCRIPTION
<!-- PR 타이틀은 브랜치 이름 앞부분 + PR 내용 -->
<!-- ex - Feat: 로그인 UI 추가 -->

## 📌 관련 이슈
<!-- 이슈 완료 전이면 close 없이 #00만 작성해주세요 -->
<!-- 이슈가 없다면 생략해도 좋습니다 -->

#14 

## ✨ 작업 내용
<!-- 작업한 내용을 명확히 요약해주세요 (예: 기능 추가/수정/제거, 리팩토링 등) -->

- 카테고리 배열 순서 변경
  - API 명세서에서 적어주신 부분과 일치하도록 일부 수정했습니다.
- 챗봇 스크랩용 SmallFilter 로직 추가
  - 유저가 지정한 관심 카테고리만 뜨는 게 아닌, 전체 카테고리가 다 뜨는 SmallFilter 로직을 추가했습니다.
- 챗봇 스크랩 컴포넌트 추가
- 챗봇 스크랩 페이지 UI 구현
  - 한 번에 하나의 챗봇 컴포넌트만 펼쳐질 수 있도록 했습니다.
  - 필터링 등 로직은 전혀 연동하지 않고, 더미데이터를 활용했습니다.
- GoToTop 조건 y범위 축소
  - 기존에 200이었던 걸 100으로 축소했습니다. 그냥... 조금만 내려도 뜨는 게 좋지 않나 싶어서요 ㅎㅎ 편하게 수정하셔도 됩니다.

## 📸 UI 작업 시
<!-- 이미지 or 영상 첨부 -->
<img width="445" height="676" alt="image" src="https://github.com/user-attachments/assets/e435edb9-5984-495a-a165-8aee5eaca5e8" />

![2025_8_16_25](https://github.com/user-attachments/assets/c99e2304-8d79-4de9-833b-35c67a03b4b5)


## ✅ 체크 리스트
<!-- 체크는 [x]로-->

- [x] develop 브랜치 pull 완료
- [x] Assignees 설정
