### PR TITLE
Design: CategoryBar 상단 고정으로 변경

### DIFF
--- a/src/components/CategoryBar/CategoryBarStyle.jsx
+++ b/src/components/CategoryBar/CategoryBarStyle.jsx
@@ -16,6 +16,11 @@ export const CategoryContainer = styled.div`
   scrollbar-width: none;
   z-index: 30;
   background-color: var(--color-base-white);
+  /* 고정 코드 추가 */
+  position: fixed;
+  top: 42px;
+  width: 100%;
+  max-width: 393px;
 `;
 
 export const CategoryItem = styled.div`

--- a/src/pages/News/NewsStyle.js
+++ b/src/pages/News/NewsStyle.js
@@ -1,5 +1,5 @@
 import styled from "styled-components";
 
 export const NewsContainer = styled.div`
-  padding-top: 42px;
+  padding-top: 85px;
 `;

--- a/src/pages/Notification/NotificationStyle.js
+++ b/src/pages/Notification/NotificationStyle.js
@@ -1,7 +1,8 @@
 import styled from "styled-components";
 
 export const NotificationContainer = styled.div`
-  padding-top: 42px;
+  /* 카테고리바도 고려해서 패딩값 늘렸습니다 */
+  padding-top: 85px;
   /* 네비게이터에 마지막 항목이 가려지지 않도록 여백 추가 => Main.jsx에 이미 있어서 일단 주석처리 */
   /* padding-bottom: 80px; */
 `;

--- a/src/pages/ScrapedPosts/ScrapedPostsStyle.js
+++ b/src/pages/ScrapedPosts/ScrapedPostsStyle.js
@@ -2,7 +2,7 @@ import styled from "styled-components";
 
 export const ScrapedContainer = styled.div`
   margin: 0 auto;
-  padding-top: 42px;
+  padding-top: 85px;
   width: 100%;
   max-width: 393px;
   box-sizing: border-box;


### PR DESCRIPTION
<!-- PR 타이틀은 브랜치 이름 앞부분 + PR 내용 -->
<!-- ex - Feat: 로그인 UI 추가 -->

## 📌 관련 이슈
<!-- 이슈 완료 전이면 close 없이 #00만 작성해주세요 -->
<!-- 이슈가 없다면 생략해도 좋습니다 -->

#28 

## ✨ 작업 내용
<!-- 작업한 내용을 명확히 요약해주세요 (예: 기능 추가/수정/제거, 리팩토링 등) -->

- (마이페이지 캐릭터 이미지 추가, 뱃지바 뜨는 방식 변경)
  - 이 부분 새 브랜치로 체크아웃 되었다고 생각하고 커밋했는데 develop에 커밋이 됐더라고요... 바로 푸시하긴 했습니다. 제 코드만 수정해서 아마 문제는 없을 거예요!
  - 홈 화면도 뱃지바 뜨는 거 배경 가운데로 하실 거면 제 방식이랑 비슷하게 하셔도 좋을 것 같습니다. 검색창을 상단 div에서 빼고, transform: translateY(-50%);를 줬어요.
- CategoryBar 상단 고정으로 변경
  - 소식, 알림 탭 상단 패딩을 이에 맞게 좀 더 줬습니다. 이거 때문에 후딱 PR 보내고 머지합니다.

## 📸 UI 작업 시
<!-- 이미지 or 영상 첨부 -->

## ✅ 체크 리스트
<!-- 체크는 [x]로-->

- [x] develop 브랜치 pull 완료
- [x] Assignees 설정
