### PR TITLE
Feat: 홈 화면, 공문 본문 페이지 일부 연동

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -42,8 +42,7 @@ function App() {
           </Route>
           <Route element={<WithoutNav />}>
             {/* Navigator가 없는 경우 이쪽에 route를 만들어주세요 */}
-            <Route path='/detail' element={<Detail />} />
-            {/* 추후 /post/:id로 경로 변경할 예정 */}
+            <Route path='/post/:id' element={<Detail />} />
             <Route path='/search' element={<Search />} />
             <Route path='/profile' element={<Profile />} />
             <Route path='/scrap/posts' element={<ScrapedPosts />} />

--- a/src/components/CardList/CardList.jsx
+++ b/src/components/CardList/CardList.jsx
@@ -8,6 +8,7 @@ export default function CardList({
   date = "",
   variant = "list",
   isUnread = false, // 안 읽음 상태 prop 추가
+  onClick,
 }) {
   // 뱃지들을 렌더링하는 부분
   const badgeComponent = (
@@ -23,7 +24,7 @@ export default function CardList({
   // "다가오는 관심 일정"의 카드 스타일일 경우
   if (variant === "card") {
     return (
-      <S.CardContainer variant={variant}>
+      <S.CardContainer $variant={variant}>
         {badgeComponent}
         <S.CardImage />
         <S.ContentWrapper>
@@ -36,7 +37,7 @@ export default function CardList({
 
   // 기본 밑줄 스타일일 경우 (알림 페이지 등)
   return (
-    <S.CardContainer variant={variant} isUnread={isUnread}>
+    <S.CardContainer $variant={variant} $isUnread={isUnread} onClick={onClick}>
       <S.ContentWrapper>
         {badgeComponent}
         <S.Title>

--- a/src/components/CardList/CardListStyle.js
+++ b/src/components/CardList/CardListStyle.js
@@ -21,7 +21,7 @@ export const UnreadMark = styled.div`
   margin-left: 8px;
 `;
 
-// 공통 리스트 스타일 
+// 공통 리스트 스타일
 const baseListStyles = css`
   border-bottom: 0.5px solid var(--color-neutral-200);
   flex-direction: row;
@@ -74,7 +74,8 @@ export const CardContainer = styled.div`
   display: flex;
   background: var(--color-base-white);
   gap: 12px;
-  ${({ variant }) => variants[variant]}
+  ${({ $variant }) => variants[$variant]}
+  cursor: pointer;
 `;
 
 export { ContentWrapper, CardImage };

--- a/src/pages/Detail/Detail.jsx
+++ b/src/pages/Detail/Detail.jsx
@@ -14,21 +14,25 @@ import buttonCircle from "../../assets/ButtonCircle.png";
 
 import * as B from "../../styles/ButtonCircle";
 import * as S from "./DetailStyle";
+import { useParams } from "react-router-dom";
+import { REGION_MAP } from "../../services/maps";
+
+const API_URL = process.env.REACT_APP_API_URL;
 
 export default function Detail() {
-  // param 등 route 작업도 추가 필요
+  const { id } = useParams();
 
   // 챗봇 열림 상태 관리
   const [isOpen, setIsOpen] = useState(false);
   const handleClose = () => setIsOpen(false);
 
+  // 공문 본문 fetch
   const { data: post, isLoading: isPostLoading } = useFetch(
-    "/data/EachDetail.json",
+    `${API_URL}/documents/${id}/`,
     {}
   );
-  // fetch url 추후 변경 예정
 
-  let isScrap = true;
+  let isScrap = false;
   // scrap 로직 추가 예정
 
   // 관련 공문 추천
@@ -41,7 +45,7 @@ export default function Detail() {
       {/* fixed 되는 컴포넌트들 */}
       <Header
         hasBack={true}
-        title={post.title}
+        title={!isPostLoading && post.doc_title}
         hasScrap={true}
         isScrap={false}
       />
@@ -58,56 +62,73 @@ export default function Detail() {
 
       {/* 페이지 UI */}
       <S.DetailContainer>
-        {/* 공문 정보 박스 */}
-        <S.InfoBox>
-          <S.BadgeWrapper>
-            <Badge>{post.region}</Badge>
-            <Badge color='teal'>{post.keyword}</Badge>
-          </S.BadgeWrapper>
-          <S.Title>{post.title}</S.Title>
-          <S.MetaInfo>
-            <S.MetaInfoLabel>
-              <li>작성일</li>
-              <li>관련부서</li>
-              <li>문의</li>
-            </S.MetaInfoLabel>
-            <S.MetaInfoData>
-              <li>{post.date}</li>
-              <li>{post.department}</li>
-              <li>{post.tel}</li>
-            </S.MetaInfoData>
-          </S.MetaInfo>
-        </S.InfoBox>
+        {!isPostLoading && post && (
+          <>
+            {/* 공문 정보 박스 */}
+            <S.InfoBox>
+              <S.BadgeWrapper>
+                <Badge key={post.region_id}>{REGION_MAP[post.region_id]}</Badge>
+                {(post.categories ?? []).map((c) => (
+                  <Badge color='teal' key={c.id}>
+                    {c.category_name}
+                  </Badge>
+                ))}
+              </S.BadgeWrapper>
+              <S.Title>{post.doc_title}</S.Title>
+              <S.MetaInfo>
+                <S.MetaInfoLabel>
+                  <li>작성일</li>
+                  <li>관련부서</li>
+                  <li>문의</li>
+                </S.MetaInfoLabel>
+                <S.MetaInfoData>
+                  <li>{post.pub_date.slice(0, 10)}</li>
+                  {/* 관련부서 추가 or 아예 삭제 필요 */}
+                  <li>관련부서</li>
+                  {/* 문의 전화번호 추가 or 아예 삭제 필요 */}
+                  <li>전화번호</li>
+                </S.MetaInfoData>
+              </S.MetaInfo>
+            </S.InfoBox>
 
-        {/* AI 요약 */}
-        <S.AIBox>
-          <S.AICharacter />
-          <S.AIHeader>
-            <S.AITitle>AI 요약</S.AITitle>
-          </S.AIHeader>
-          <S.Content>{post.aiSummary}</S.Content>
-        </S.AIBox>
+            {/* AI 요약 */}
+            <S.AIBox>
+              <S.AICharacter />
+              <S.AIHeader>
+                <S.AITitle>AI 요약</S.AITitle>
+              </S.AIHeader>
+              {/* 추가 예정 */}
+              <S.Content>
+                추가 예정 추가 예정 추가 예정 추가 예정 추가 예정 추가 예정 추가
+                예정 추가 예정 추가 예정 추가 예정 추가 예정 추가 예정 추가 예정
+                추가 예정 추가 예정 추가 예정
+              </S.Content>
+            </S.AIBox>
 
-        {/* 본문 */}
-        <S.ContentBox>
-          <S.Content>{post.content}</S.Content>
-          <img src={post.imgLink} />
-        </S.ContentBox>
+            {/* 본문 */}
+            <S.ContentBox>
+              <S.Content>{post.doc_content.replaceAll(".", ". ")}</S.Content>
+              {/* 추가 예정 */}
+              <img src={post.image_url} />
+            </S.ContentBox>
 
-        {/* 본문 하단 버튼 */}
-        <S.ButtonBox>
-          <S.LinkBtn href={post.url}>원문 바로가기</S.LinkBtn>
-          <S.SecondBtnBox>
-            <S.SecondBtn>
-              <img src={isScrap ? scrapTrue : scrapFalse} />
-              스크랩
-            </S.SecondBtn>
-            <S.SecondBtn>
-              <img src={share} />
-              공유하기
-            </S.SecondBtn>
-          </S.SecondBtnBox>
-        </S.ButtonBox>
+            {/* 본문 하단 버튼 */}
+            <S.ButtonBox>
+              {/* 추가 필요 */}
+              <S.LinkBtn href={post.url}>원문 바로가기</S.LinkBtn>
+              <S.SecondBtnBox>
+                <S.SecondBtn>
+                  <img src={isScrap ? scrapTrue : scrapFalse} />
+                  스크랩
+                </S.SecondBtn>
+                <S.SecondBtn>
+                  <img src={share} />
+                  공유하기
+                </S.SecondBtn>
+              </S.SecondBtnBox>
+            </S.ButtonBox>
+          </>
+        )}
 
         {/* 관련 공문 추천 */}
         <S.RecommendBox>

--- a/src/pages/Detail/DetailStyle.js
+++ b/src/pages/Detail/DetailStyle.js
@@ -92,7 +92,7 @@ export const AIBox = styled.div`
 
 export const AICharacter = styled.div`
   width: 171.592px;
-  height: 146.71px;
+  height: 100%;
   aspect-ratio: 131/112;
   opacity: 0.4; /* 시안과 비슷하게 가려고 일부러 오퍼시티 더 낮춤 */
   background-image: url(${summaryCharacter});

--- a/src/services/makeBadges.js
+++ b/src/services/makeBadges.js
@@ -1,0 +1,12 @@
+import { REGION_MAP } from "./maps";
+
+export const makeBadges = (r) => [
+  {
+    text: REGION_MAP[r.region_id],
+    color: "blue",
+  },
+  ...(r.categories ?? []).map((c) => ({
+    text: c.category_name,
+    color: "teal",
+  })),
+];

--- a/src/services/maps.js
+++ b/src/services/maps.js
@@ -1,0 +1,24 @@
+// CATEGORY_OPTIONS 인덱스로 갖다 써도 될 것 같지만 일단 필요할 것 같아서 적어둡니다
+export const CATEGORY_MAP = {
+  0: "모든 주제",
+  1: "교통",
+  2: "문화",
+  3: "주택",
+  4: "경제",
+  5: "환경",
+  6: "안전",
+  7: "복지",
+  8: "행정",
+};
+
+// id로 지역 매핑
+export const REGION_MAP = {
+  6: "도봉구",
+  85: "경기도",
+};
+
+// 지역명으로 id 매핑
+export const NAME_REGION_MAP = {
+  도봉구: 6,
+  경기도: 85,
+};


### PR DESCRIPTION
<!-- PR 타이틀은 브랜치 이름 앞부분 + PR 내용 -->
<!-- ex - Feat: 로그인 UI 추가 -->

## 📌 관련 이슈
<!-- 이슈 완료 전이면 close 없이 #00만 작성해주세요 -->
<!-- 이슈가 없다면 생략해도 좋습니다 -->

#28 

## ✨ 작업 내용
<!-- 작업한 내용을 명확히 요약해주세요 (예: 기능 추가/수정/제거, 리팩토링 등) -->

- 카테고리, 지역명 매핑하는 함수 파일 추가
- CardList Badge prop에 실제 데이터 map하는 함수 추가
  - 이거 제가 좀 급하게 구현하느라 주석으로 어떻게 쓰는 건지 설명을 못 달아놨네요,, 다음 push 때 추가하겠습니다. 그 전에 궁금하시다면 언제든 연락 주세요!
- 공문 본문 페이지 일부 연동
  - useParams() 이용하는 동적 경로로 교체
  - 스크랩, 챗봇, 관련 공문 추천, 이미지, AI 요약 제외 연동
- 홈 화면 일부 연동
  - 다가오는 관심 일정 제외 연동 (다가오는 관심일정 더보기 경로도 수정 필요. scrap/posts?category=participation 이런 식으로 바뀌어야 하는데, 쿼리스트링 받아올 필요 있음)
  - 검색 페이지는 따로라고 생각하겠습니다. 검색 API는 아직 개발중인 것 같습니다,,!

## 📸 UI 작업 시
<!-- 이미지 or 영상 첨부 -->
<img width="433" height="670" alt="image" src="https://github.com/user-attachments/assets/30dbf54d-65ea-4f7f-95a7-d39e3dfd212c" />
<img width="458" height="669" alt="image" src="https://github.com/user-attachments/assets/043511e9-b142-44f0-99f9-beb2b9b1cb66" />

## ✅ 체크 리스트
<!-- 체크는 [x]로-->

- [x] develop 브랜치 pull 완료
- [x] Assignees 설정
