### PR TITLE
Fix: 알림 탭 무한 렌더 오류 수정

### DIFF
--- a/src/pages/Notification/Notification.jsx
+++ b/src/pages/Notification/Notification.jsx
@@ -59,7 +59,7 @@ export default function Notification() {
   const listUrl = useMemo(() => {
     const params = new URLSearchParams();
     params.set("user_id", "GUEST1"); // 고정
-    params.set("page", 1); // 일단 고정
+    params.set("page", "1"); // 일단 고정
     if (docType) params.set("doc_type", docType);
     if (regionKey) params.set("region_ids", regionKey);
     if (categoryKey) params.set("category_ids", categoryKey);


### PR DESCRIPTION
<!-- PR 타이틀은 브랜치 이름 앞부분 + PR 내용 -->
<!-- ex - Feat: 로그인 UI 추가 -->

## 📌 관련 이슈
<!-- 이슈 완료 전이면 close 없이 #00만 작성해주세요 -->
<!-- 이슈가 없다면 생략해도 좋습니다 -->

## ✨ 작업 내용
<!-- 작업한 내용을 명확히 요약해주세요 (예: 기능 추가/수정/제거, 리팩토링 등) -->

- 필터링 로직 구현 이후 알림 탭 무한 렌더되던 오류 수정
  - 아직 알림 데이터가 없어서 필터링 로직에도 영향이 있진 않은지 알 수 없지만, 필터 누를 때마다 새로 렌더되는 걸로 봐선 아마 잘 작동될 것 같습니다.

## 📸 UI 작업 시
<!-- 이미지 or 영상 첨부 -->

## ✅ 체크 리스트
<!-- 체크는 [x]로-->

- [x] develop 브랜치 pull 완료
- [x] Assignees 설정
