### PR TITLE
Fix: 스크랩된 공문 무한 렌더 수정, 알림 탭 데이터 출력 수정

### DIFF
--- a/src/pages/Notification/Notification.jsx
+++ b/src/pages/Notification/Notification.jsx
@@ -9,7 +9,7 @@ import * as S from "./NotificationStyle";
 import * as F from "../../components/SmallFilter/SmallFilterStyle";
 import useFetch from "../../hooks/useFetch";
 import NotificationEmpty from "./NotificationEmpty";
-import { makeScrapBadges } from "../../utils/makeBadges"; // 뱃지 생성 유틸리티
+import { makeNotiBadges } from "../../utils/makeBadges"; // 뱃지 생성 유틸리티
 import { useNavigate } from "react-router-dom"; // 페이지 이동 훅
 import {
   CATEGORY_TYPE_MAP,
@@ -73,7 +73,9 @@ export default function Notification() {
   );
 
   // 실제 알림 목록은 API 응답의 'results' 안에 들어있습니다.
-  const notifications = notificationData?.results ?? [];
+  const notifications = notificationData?.data?.results ?? [];
+
+  console.log(notifications);
 
   return (
     <>
@@ -99,13 +101,13 @@ export default function Notification() {
               <CardList
                 key={item.id}
                 variant='notification'
-                badges={makeScrapBadges(item)} // API 데이터에 맞게 뱃지 생성
-                title={item.doc_title} // 실제 제목 데이터
-                date={item.pub_date.slice(0, 10)} // 실제 날짜 데이터
+                badges={makeNotiBadges(item)} // API 데이터에 맞게 뱃지 생성
+                title={item.title} // 실제 제목 데이터
+                date={item.notification_time.slice(0, 10)} // 실제 날짜 데이터
                 isUnread={!item.is_read} // '읽음' 상태의 반대로 '안읽음' 표시
-                onClick={() => navigate(`/post/${item.id}`)} // 클릭 시 상세 페이지로 이동
-                image={item.image_url}
-                type={item.doc_type}
+                onClick={() => navigate(`/post/${item.document_info.id}`)} // 클릭 시 상세 페이지로 이동
+                image={item.document_info.image_url}
+                type={item.document_info.doc_type}
               />
             ))
           ) : (

--- a/src/pages/Notification/Notification.jsx
+++ b/src/pages/Notification/Notification.jsx
@@ -75,8 +75,6 @@ export default function Notification() {
   // 실제 알림 목록은 API 응답의 'results' 안에 들어있습니다.
   const notifications = notificationData?.data?.results ?? [];
 
-  console.log(notifications);
-
   return (
     <>
       <Header hasBack={false} title='알림' hasScrap={false} />

--- a/src/pages/ScrapedPosts/ScrapedPosts.jsx
+++ b/src/pages/ScrapedPosts/ScrapedPosts.jsx
@@ -105,7 +105,7 @@ export default function ScrapedPosts() {
     params.set("page_size", PAGE_SIZE);
 
     return `${API_URL}/scrap/documents/?${params.toString()}`;
-  }, [order, docType, regionIds, categoryIds]);
+  }, [order, docType, regionIds, categoryIds, page]);
 
   // 공문 스크랩 (URL 바뀔 때마다)
   const { data: postdata, isLoading: isPostsLoading } = useFetch(listUrl, {});

--- a/src/utils/makeBadges.js
+++ b/src/utils/makeBadges.js
@@ -22,3 +22,15 @@ export const makeScrapBadges = (r) => [
     color: "teal",
   })),
 ];
+
+// 알림 목록 조회 API 응답 데이터에 맞춰 수정
+export const makeNotiBadges = (r) => [
+  {
+    text: REGION_MAP[r.document_info.region_id],
+    color: "blue",
+  },
+  ...(r.document_info.category_tags ?? []).map((c) => ({
+    text: c,
+    color: "teal",
+  })),
+];


### PR DESCRIPTION
<!-- PR 타이틀은 브랜치 이름 앞부분 + PR 내용 -->
<!-- ex - Feat: 로그인 UI 추가 -->

## 📌 관련 이슈
<!-- 이슈 완료 전이면 close 없이 #00만 작성해주세요 -->
<!-- 이슈가 없다면 생략해도 좋습니다 -->

## ✨ 작업 내용
<!-- 작업한 내용을 명확히 요약해주세요 (예: 기능 추가/수정/제거, 리팩토링 등) -->

- 스크랩한 공문 무한 렌더 수정
  - fetch할 URL의 useMemo 의존성 배열에 page를 추가해 page에 따라 URL이 바뀌도록 해 수정함
- 알림 탭 데이터 출력 수정
  - 어제까지는 알림 탭에 데이터가 안 떠서 어떻게 뜨는지 확인을 못했는데, 확인을 완료해서 잘 뜨도록 바꿔뒀습니다. 
  - 이제 안읽음 표시 관련 로직과 푸시 알림 테스트 버튼 정도만 추가하면 알림 탭 기능도 구현 완료될 것 같습니다. 후자는 제가 할 예정입니다!

## 📸 UI 작업 시
<!-- 이미지 or 영상 첨부 -->

## ✅ 체크 리스트
<!-- 체크는 [x]로-->

- [x] develop 브랜치 pull 완료
- [x] Assignees 설정
